### PR TITLE
Update OHDSI master yaml

### DIFF
--- a/OHDSI-master.yaml
+++ b/OHDSI-master.yaml
@@ -244,7 +244,7 @@ Resources:
     DependsOn: VPCStack
     Properties:
       Description: CloudFormation Sample Aurora Cluster Parameter Group
-      Family: aurora-postgresql9.6
+      Family: aurora-postgresql10
       Parameters:
         rds.force_ssl: 1
   RDSDBParameterGroup:
@@ -252,7 +252,7 @@ Resources:
     DependsOn: VPCStack
     Properties:
       Description: CloudFormation Sample Aurora Parameter Group
-      Family: aurora-postgresql9.6
+      Family: aurora-postgresql10
       Parameters:
         log_rotation_age: 60
   RDSDBSubnets:


### PR DESCRIPTION
RDSDBClusterParameterGroup:
Family: "aurora-postgresql9.6" No-Longer working, updated the parameter to "aurora-postgresql10" and works

Regards,
Eric

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
